### PR TITLE
Ejh test

### DIFF
--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -41,6 +41,13 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
+
+      - name: install-intel-compilers
+        uses: NOAA-EMC/ci-install-intel-toolkit
+        with:
+          install-oneapi: false
+          install-mpi: true
+
       - name: checkout-upp  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
         uses: actions/checkout@v2
@@ -69,8 +76,9 @@ jobs:
           spack compiler find
           sudo apt install cmake
           spack external find
-          spack add intel-oneapi-mpi
           spack config add "packages:all:prefer:'%intel'"
+          spack config add "packages:mpi:require:intel-oneapi-mpi"
+          spack config add "packages:mpi:buildable:false"
           spack concretize
           spack install --dirty --fail-fast hdf5
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
 
       - name: install-intel-compilers
-        uses: NOAA-EMC/ci-install-intel-toolkit
+        uses: NOAA-EMC/ci-install-intel-toolkit@develop
         with:
           install-oneapi: false
           install-mpi: true

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -73,7 +73,7 @@ jobs:
           cd /dev/shm
           git clone -c feature.manyFiles=true https://github.com/NOAA-EMC/spack.git
           source spack/share/spack/setup-env.sh
-          spack env create upp-env UPP/ci/spack.yaml
+          spack env create upp-env $GITHUB_WORKSPACE/UPP/ci/spack.yaml
           spack env activate upp-env
           spack compiler find
           sudo apt install cmake

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -81,7 +81,6 @@ jobs:
           spack config add "packages:all:prefer:'%intel'"
           spack config add "packages:mpi:require:intel-oneapi-mpi"
           spack config add "packages:mpi:buildable:false"
-          echo -e "  packages:\n    intel-oneapi-mpi:\n      externals:\n      - spec: intel-oneapi-mpi@2021.10.0\n        prefix: /opt/intel/oneapi/" >> $SPACK_ENV/spack.yaml
           spack concretize
           spack install --dirty --fail-fast
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -46,6 +46,8 @@ jobs:
         uses: NOAA-EMC/ci-install-intel-toolkit@develop
         with:
           install-oneapi: false
+          install-mpi: true
+          mpi-version: 2021.10.0
 
       - name: checkout-upp  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -59,7 +61,7 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            spack
+            /dev/shm/spack
             ~/.spack
             /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('UPP/ci/spack.yaml') }}
@@ -68,6 +70,7 @@ jobs:
       - name: install-dependencies-with-spack
         if: steps.cache-env.outputs.cache-hit != 'true'
         run: |
+          cd /dev/shm
           git clone -c feature.manyFiles=true https://github.com/NOAA-EMC/spack.git
           source spack/share/spack/setup-env.sh
           spack env create upp-env UPP/ci/spack.yaml
@@ -77,6 +80,8 @@ jobs:
           spack external find
           spack config add "packages:all:prefer:'%intel'"
           spack config add "packages:mpi:require:intel-oneapi-mpi"
+          spack config add "packages:mpi:buildable:false"
+          echo -e "packages:\n  intel-oneapi-mpi:\n    externals:\n    - spec: intel-oneapi-mpi@2021.10.0\n      prefix: /opt/intel/oneapi/" >> $SPACK_ENV/spack.yaml
           spack concretize
           spack install --dirty --fail-fast
 
@@ -106,13 +111,14 @@ jobs:
         uses: actions/cache@v3
         with:
           path: |
-            spack
+            /dev/shm/spack
             ~/.spack
             /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('UPP/ci/spack.yaml') }}
 
       - name: build-upp
         run: |
+          cd /dev/shm
           source spack/share/spack/setup-env.sh
           spack env activate upp-env
           spack config add "packages:all:prefer:['%intel']"

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -71,8 +71,13 @@ jobs:
           spack external find
           spack add intel-oneapi-mpi
           spack concretize
-          spack install --dirty --fail-fast
-          spack clean --all
+          spack install --dirty --fail-fast hdf5
+
+      - name: upload-artifacts
+        use: actions/upload-artifact@v4
+        path: |
+          /home/runner/work/UPP/UPP/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.5.0/intel-oneapi-mpi-2021.12.1-*/mpi/2021.12/include/mpi/mpi.mod
+          /tmp/runner/spack-stage/spack-stage-nemsio-2.5.4-*/spack-build-out.txt
 
   build:
     needs: setup

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -81,7 +81,7 @@ jobs:
           spack config add "packages:all:prefer:'%intel'"
           spack config add "packages:mpi:require:intel-oneapi-mpi"
           spack config add "packages:mpi:buildable:false"
-          echo -e "packages:\n  intel-oneapi-mpi:\n    externals:\n    - spec: intel-oneapi-mpi@2021.10.0\n      prefix: /opt/intel/oneapi/" >> $SPACK_ENV/spack.yaml
+          echo -e "  packages:\n    intel-oneapi-mpi:\n      externals:\n      - spec: intel-oneapi-mpi@2021.10.0\n        prefix: /opt/intel/oneapi/" >> $SPACK_ENV/spack.yaml
           spack concretize
           spack install --dirty --fail-fast
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -74,7 +74,7 @@ jobs:
           spack install --dirty --fail-fast hdf5
 
       - name: upload-artifacts
-        use: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4
         path: |
           /home/runner/work/UPP/UPP/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.5.0/intel-oneapi-mpi-2021.12.1-*/mpi/2021.12/include/mpi/mpi.mod
           /tmp/runner/spack-stage/spack-stage-nemsio-2.5.4-*/spack-build-out.txt

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -70,6 +70,7 @@ jobs:
           sudo apt install cmake
           spack external find
           spack add intel-oneapi-mpi
+          spack config add "packages:all:prefer:'%intel'"
           spack concretize
           spack install --dirty --fail-fast hdf5
 

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -63,7 +63,6 @@ jobs:
           path: |
             /dev/shm/spack
             ~/.spack
-            /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('UPP/ci/spack.yaml') }}
 
       # Install dependencies using Spack
@@ -105,7 +104,6 @@ jobs:
           path: |
             /dev/shm/spack
             ~/.spack
-            /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('UPP/ci/spack.yaml') }}
 
       - name: build-upp

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -111,8 +111,7 @@ jobs:
 
       - name: build-upp
         run: |
-          cd /dev/shm
-          source spack/share/spack/setup-env.sh
+          source /dev/shm/spack/share/spack/setup-env.sh
           spack env activate upp-env
           spack config add "packages:all:prefer:['%intel']"
           export CC=mpiicc

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -46,7 +46,6 @@ jobs:
         uses: NOAA-EMC/ci-install-intel-toolkit@develop
         with:
           install-oneapi: false
-          install-mpi: true
 
       - name: checkout-upp  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -78,9 +77,8 @@ jobs:
           spack external find
           spack config add "packages:all:prefer:'%intel'"
           spack config add "packages:mpi:require:intel-oneapi-mpi"
-          spack config add "packages:mpi:buildable:false"
           spack concretize
-          spack install --dirty --fail-fast hdf5
+          spack install --dirty --fail-fast
 
       - name: upload-artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -48,6 +48,7 @@ jobs:
           install-oneapi: false
           install-mpi: true
           mpi-version: 2021.10.0
+          cache: false
 
       - name: checkout-upp  # This is for getting spack.yaml
         if: steps.cache-env.outputs.cache-hit != 'true'
@@ -63,6 +64,7 @@ jobs:
           path: |
             /dev/shm/spack
             ~/.spack
+            /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('UPP/ci/spack.yaml') }}
 
       # Install dependencies using Spack
@@ -104,6 +106,7 @@ jobs:
           path: |
             /dev/shm/spack
             ~/.spack
+            /opt/intel
           key: spack-${{ runner.os }}-${{ env.cache_key }}-${{ hashFiles('UPP/ci/spack.yaml') }}
 
       - name: build-upp

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -84,13 +84,6 @@ jobs:
           spack concretize
           spack install --dirty --fail-fast
 
-      - name: upload-artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          path: |
-            /home/runner/work/UPP/UPP/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.5.0/intel-oneapi-mpi-2021.12.1-*/mpi/2021.12/include/mpi/mpi.mod
-            /tmp/runner/spack-stage/spack-stage-nemsio-2.5.4-*/spack-build-out.txt
-
   build:
     needs: setup
     runs-on: ubuntu-20.04

--- a/.github/workflows/intel.yml
+++ b/.github/workflows/intel.yml
@@ -75,9 +75,10 @@ jobs:
 
       - name: upload-artifacts
         uses: actions/upload-artifact@v4
-        path: |
-          /home/runner/work/UPP/UPP/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.5.0/intel-oneapi-mpi-2021.12.1-*/mpi/2021.12/include/mpi/mpi.mod
-          /tmp/runner/spack-stage/spack-stage-nemsio-2.5.4-*/spack-build-out.txt
+        with:
+          path: |
+            /home/runner/work/UPP/UPP/spack/opt/spack/linux-ubuntu20.04-zen2/gcc-10.5.0/intel-oneapi-mpi-2021.12.1-*/mpi/2021.12/include/mpi/mpi.mod
+            /tmp/runner/spack-stage/spack-stage-nemsio-2.5.4-*/spack-build-out.txt
 
   build:
     needs: setup

--- a/ci/spack.yaml
+++ b/ci/spack.yaml
@@ -5,6 +5,10 @@ spack:
       compiler:
       - intel
       - gcc@10:10
+    intel-oneapi-mpi:
+      externals:
+      - spec: intel-oneapi-mpi@2021.10.0
+        prefix: /opt/intel/oneapi/
   specs:
   - netcdf-c@4.9.2
   - netcdf-fortran@4.6.1


### PR DESCRIPTION
The problem currently is that it's building with gcc. This is at least in part a result of the intel installation step being removed. I can get the workflow going with a handful of changes. To save space, I'm using the apt-installed intel-oneapi-mpi (which apparently is installed no matter what as a requirement of the fortran package), and I'm also installing spack and UPP under /dev/shm, though this may not still be necessary with intel MPI no longer being redundantly installed through spack.